### PR TITLE
修复 [ 打开Web界面 ] 按钮显示

### DIFF
--- a/luci-app-alist/luasrc/view/alist/alist_status.htm
+++ b/luci-app-alist/luasrc/view/alist/alist_status.htm
@@ -17,7 +17,7 @@
 			{
 				if (st.running)
 				{
-					tb.innerHTML = '<em style=\"color:green\"><b>Alist <%:RUNNING%></b></em>' + "<input class=\"cbi-button-reload mar-10\" type=\"button\" value=\" <%:Open Web Interface%> \" onclick=\"window.open('<%=protocol%>" + window.location.hostname + ":" + st.port + "/')\"/>";
+					tb.innerHTML = '<em style=\"color:green\"><b>Alist <%:RUNNING%></b></em>' + "<input class=\"cbi-button mar-10\" type=\"button\" value=\" <%:Open Web Interface%> \" onclick=\"window.open('<%=protocol%>" + window.location.hostname + ":" + st.port + "/')\"/>";
 				}
 				else
 				{


### PR DESCRIPTION
在 openwrt 18.06 中 [ 打开Web界面 ] 按钮背景出现 reload 图标平铺，造成 [ 打开Web界面 ] 文字完全无法看清，修改为普通按钮样式。