### PR TITLE
init script supports new ipaddr syntax

### DIFF
--- a/luci-app-alist/root/etc/init.d/alist
+++ b/luci-app-alist/root/etc/init.d/alist
@@ -17,6 +17,7 @@ get_config() {
 	config_get allow_wan $1 allow_wan 0
 	config_load network
 	config_get lan_addr lan ipaddr "0.0.0.0"
+	lan_addr=${lan_addr%%/*}
 }
 
 set_firewall() {


### PR DESCRIPTION
luci 21以上，支持 ip/码位 的格式，例如 "192.168.100.1/24"，修改init脚本将 “/” 和后面的数字去掉，以免alist启动失败