### PR TITLE
init script supports new ipaddr syntax

### DIFF
--- a/luci-app-alist/root/etc/init.d/alist
+++ b/luci-app-alist/root/etc/init.d/alist
@@ -17,7 +17,11 @@ get_config() {
 	config_get allow_wan $1 allow_wan 0
 	config_load network
 	config_get lan_addr lan ipaddr "0.0.0.0"
-	lan_addr=${lan_addr%%/*}
+	if echo "${lan_addr}" | grep -Fq ' '; then
+		lan_addr="0.0.0.0"
+	else
+		lan_addr=${lan_addr%%/*}
+	fi
 }
 
 set_firewall() {

--- a/luci-app-alist/root/etc/init.d/alist
+++ b/luci-app-alist/root/etc/init.d/alist
@@ -17,6 +17,7 @@ get_config() {
 	config_get allow_wan $1 allow_wan 0
 	config_load network
 	config_get lan_addr lan ipaddr "0.0.0.0"
+	lan_addr=${lan_addr%%/*}
 }
 
 set_firewall() {


### PR DESCRIPTION
luci 21 以上 ipaddr 支持 “ip/掩码” 格式，例如 “192.168.100.1/24” ，并且使用这种格式的情况下支持多个 ip 地址。

所以
1. 脚本中判断 lan 有多个 ip 时，直接监听 `0.0.0.0`，因为看起来生成的 alist 配置文件不支持监听多个 ip；
2. 如果遇到 “ip/掩码” 格式，则删除 "/" 和之后的内容。